### PR TITLE
Handle trailing slashes

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ func main() {
 	log.Info("Booting up")
 
 	site := echo.New()
+	site.Pre(middleware.RemoveTrailingSlash())
 	site.IPExtractor = echo.ExtractIPDirect()
 	setup.Middleware(site)
 


### PR DESCRIPTION
Prevents `api.akl.gg/layouts/` and similar from 404ing by stripping all trailing slashes from all requests